### PR TITLE
 Add deployment and shutdown ansible playbooks with management script

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -1,0 +1,109 @@
+- name: Deploy Shortly Application
+  hosts: localhost
+  gather_facts: no
+  vars:
+    project_dir: "{{ lookup('env', 'PROJECT_DIR') }}"
+
+  tasks:
+    - name: Stop existing containers
+      command: docker compose down
+      args:
+        chdir: "{{ project_dir }}"
+      ignore_errors: yes
+
+    - name: Build and start services
+      command: docker compose up -d --build
+      args:
+        chdir: "{{ project_dir }}"
+      register: build_result
+
+    - name: Display build logs
+      debug:
+        msg:
+          - "Build and startup logs:"
+          - "{{ build_result.stdout_lines | default(['No build output']) }}"
+          - "{{ build_result.stderr_lines | default([]) }}"
+
+    - name: Check container status after startup
+      command: docker compose ps
+      args:
+        chdir: "{{ project_dir }}"
+      register: container_status
+
+    - name: Display container status
+      debug:
+        msg:
+          - "Container Status:"
+          - "{{ container_status.stdout_lines }}"
+
+    - name: Wait for initial startup
+      pause:
+        seconds: 5
+
+    # Start health checks individually in parallel
+    - name: Start Frontend health check (async)
+      uri:
+        url: http://localhost:3000/health
+        method: GET
+        status_code: 200
+      register: ui_job
+      async: 60
+      poll: 0
+      ignore_errors: yes
+
+    - name: Start URL Service health check (async)
+      uri:
+        url: http://localhost:8080/actuator/health
+        method: GET
+        status_code: 200
+      register: url_job
+      async: 75
+      poll: 0
+      ignore_errors: yes
+
+    - name: Start Analytics Service health check (async)
+      uri:
+        url: http://localhost:8081/actuator/health
+        method: GET
+        status_code: 200
+      register: analytics_job
+      async: 75
+      poll: 0
+      ignore_errors: yes
+
+    # Wait for all health checks with retries
+    - name: Wait for Frontend health check
+      async_status:
+        jid: "{{ ui_job.ansible_job_id }}"
+      register: ui_result
+      until: ui_result.finished
+      retries: 30
+      delay: 2
+      ignore_errors: yes
+
+    - name: Wait for URL Service health check
+      async_status:
+        jid: "{{ url_job.ansible_job_id }}"
+      register: url_result
+      until: url_result.finished
+      retries: 40
+      delay: 2
+      ignore_errors: yes
+
+    - name: Wait for Analytics Service health check
+      async_status:
+        jid: "{{ analytics_job.ansible_job_id }}"
+      register: analytics_result
+      until: analytics_result.finished
+      retries: 40
+      delay: 2
+      ignore_errors: yes
+
+    - name: Display results
+      debug:
+        msg:
+          - "=== DEPLOYMENT COMPLETED ==="
+          - "MOD-UI (port 3000): {{ 'HEALTHY' if ui_result.finished and ui_result.status == 200 else 'UNHEALTHY' }}"
+          - "MOD-URL (port 8080): {{ 'HEALTHY' if url_result.finished and url_result.status == 200 else 'UNHEALTHY' }}"
+          - "MOD-Analytics (port 8081): {{ 'HEALTHY' if analytics_result.finished and analytics_result.status == 200 else 'UNHEALTHY' }}"
+          - "============================"

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible/manage.sh
+++ b/ansible/manage.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+# Default values
+PROJECT_DIR="${PROJECT_DIR:-$(pwd)/..}"
+
+# Export environment variables
+export PROJECT_DIR
+
+show_info() {
+    echo "Project directory: $PROJECT_DIR"
+    echo ""
+}
+
+case "$1" in
+    "start")
+        echo "Starting Shortly..."
+        show_info
+        ansible-playbook -i hosts deploy.yml
+        ;;
+    "stop")
+        echo "Stopping Shortly..."
+        show_info
+        ansible-playbook -i hosts shutdown.yml
+        ;;
+    "restart")
+        echo "Restarting Shortly..."
+        show_info
+        echo "Stopping services..."
+        ansible-playbook -i hosts shutdown.yml
+        echo ""
+        echo "Waiting 5 seconds..."
+        sleep 5
+        echo ""
+        echo "Starting services..."
+        ansible-playbook -i hosts deploy.yml
+        ;;
+    "status")
+        echo "Checking Shortly's status..."
+        show_info
+        cd "$PROJECT_DIR" && docker compose ps
+        echo ""
+        echo "  Expected URLs (if running):"
+        echo "  MOD-UI: http://localhost:3000"
+        echo "  MOD-URL: http://localhost:8080"
+        echo "  MOD-Analytics: http://localhost:8081"
+        echo "  Grafana: http://localhost:3001"
+        echo "  Prometheus: http://localhost:9090"
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|status}"
+        echo ""
+        echo "Commands:"
+        echo "  start    - Deploy and start all services"
+        echo "  stop     - Stop all services (preserve data)"
+        echo "  restart  - Stop then start services"
+        echo "  status   - Show current container status"
+        echo ""
+        echo "Environment variables:"
+        echo "  PROJECT_DIR - Project directory (default: ../)"
+        echo ""
+        echo "Examples:"
+        echo "  $0 start"
+        echo "  PROJECT_DIR=/custom/path $0 start"
+        exit 1
+        ;;
+esac

--- a/ansible/shutdown.yml
+++ b/ansible/shutdown.yml
@@ -1,0 +1,31 @@
+- name: Shutdown URL Shortener
+  hosts: localhost
+  gather_facts: no
+  vars:
+    project_dir: "{{ lookup('env', 'PROJECT_DIR') }}"
+
+  tasks:
+    - name: Stop all services
+      command: docker compose down
+      args:
+        chdir: "{{ project_dir }}"
+      register: shutdown_result
+
+    - name: Check container status
+      command: docker compose ps
+      args:
+        chdir: "{{ project_dir }}"
+      register: container_status
+
+    - name: Display shutdown results
+      debug:
+        msg:
+          - "=== SHUTDOWN COMPLETED ==="
+          - "All services stopped"
+          - "Containers removed"
+          - "Data volumes preserved"
+          - "Ports freed: 3000, 8080, 8081, 3001, 9090"
+
+    - name: Show remaining containers
+      debug:
+        var: container_status.stdout_lines


### PR DESCRIPTION
This pull request introduces an Ansible-based deployment and management framework for the Shortly application. It includes playbooks for deploying and shutting down services, a helper script for managing operations, and a configuration file for local execution. The changes aim to streamline deployment, improve maintainability, and provide clear feedback during operations.

### Deployment and Shutdown Playbooks

* **Deployment Playbook (`ansible/deploy.yml`)**: Added a playbook to automate deployment, including stopping existing containers, rebuilding and starting services, performing health checks, and displaying deployment results. This ensures a seamless and reliable deployment process.
* **Shutdown Playbook (`ansible/shutdown.yml`)**: Added a playbook to stop all services, verify container status, and provide a summary of the shutdown process. This simplifies the cleanup of resources while preserving data volumes.

### Management Script

* **Helper Script (`ansible/manage.sh`)**: Added a Bash script to manage the application lifecycle with commands like `start`, `stop`, `restart`, and `status`. It integrates with the playbooks and provides user-friendly outputs, including expected service URLs and environment variable support.

### Configuration

* **Host Configuration (`ansible/hosts`)**: Added a configuration file defining the localhost as the target for Ansible operations, enabling local execution of playbooks.