### PR TITLE
Add permissions for GITHUB_TOKEN in CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ main ]
 
+# Add permissions for GITHUB_TOKEN
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
 jobs:
   test-mod-url:
     name: Test URL Service


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to enhance security and functionality by adding specific permissions for the `GITHUB_TOKEN`.

Workflow configuration updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR9-R14): Added explicit `permissions` settings for `GITHUB_TOKEN`, granting `contents: read`, `security-events: write`, and `actions: read` to ensure proper access control during workflow execution.