### PR TITLE
Add permissions for GITHUB_TOKEN in CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
   contents: read
   security-events: write
   actions: read
+  packages: write
 
 jobs:
   test-mod-url:


### PR DESCRIPTION
This pull request updates the permissions in the GitHub Actions workflow configuration file to enable writing to packages. 

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR14): Added `packages: write` to the `permissions` section to allow workflows to write to packages.